### PR TITLE
fix(cmake): make dash_static find libedit headers on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,13 @@ set(DASH_SOURCES
     ${DASH_SRC_DIR}/syntax.c
 )
 
+set(LIBEDIT_INSTALL_DIR ${CMAKE_BINARY_DIR}/libedit-prefix)
+
 add_library(dash_static STATIC ${DASH_SOURCES})
 
 target_include_directories(dash_static
     PUBLIC
+        ${LIBEDIT_INSTALL_DIR}/include
         ${DASH_SRC_DIR}
         ${DASH_ROOT}       # for config.h
 )
@@ -255,6 +258,7 @@ if(APPLE)
 endif()
 
 add_dependencies(boxsh libedit_vendored)
+add_dependencies(dash_static libedit_vendored)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

On Linux, a clean `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build` against `master` (`72bc8c2`, v2.1.0) fails to compile `dash_static`:

```
/home/logic/boxsh/third_party/dash-0.5.12/src/myhistedit.h:34:10:
fatal error: histedit.h: No such file or directory
   34 | #include <histedit.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

## Root cause

`CMakeLists.txt` wires `dash_static`'s include dirs at line 73:

```cmake
target_include_directories(dash_static
    PUBLIC
        ${DASH_SRC_DIR}
        ${DASH_ROOT}
)
```

But `LIBEDIT_INSTALL_DIR` (where libedit's `histedit.h` lands after `libedit_vendored` builds) is only defined at line 116, so `dash_static` has no visibility into libedit's headers. On top of that, `dash_static` has no explicit dependency on `libedit_vendored`, so CMake is free to start compiling dash sources before libedit's headers are installed.

Linux reproduces this because the dash build unconditionally requires `histedit.h`. macOS happens to resolve the header through another search path, which is why the regression was not caught there.

## Fix

Three small, additive changes to `CMakeLists.txt`:

1. Move `set(LIBEDIT_INSTALL_DIR ${CMAKE_BINARY_DIR}/libedit-prefix)` **before** `add_library(dash_static)`, so the variable is defined before it is used.
2. Add `${LIBEDIT_INSTALL_DIR}/include` to `target_include_directories(dash_static)` so `#include <histedit.h>` resolves.
3. Add `add_dependencies(dash_static libedit_vendored)` so the external libedit build (which `install`s `histedit.h` into that include dir) completes before `dash_static` compilation starts.

Diff is 4 lines, no logic changed elsewhere.

## Verification

Tested on Ubuntu 24.04 LTS (x86_64):

**With the patch — clean Release build succeeds:**

```
$ rm -rf build && cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j8
...
[100%] Linking CXX executable boxsh
[100%] Built target boxsh
-rwxrwxr-x 1 logic logic 1.6M build/boxsh
```

Basic smoke tests all pass:

| Check | Result |
|---|---|
| `boxsh --version` | `boxsh version 2.1.0` |
| `boxsh -c 'echo hi'` | `hi` |
| `boxsh --sandbox -c 'cat /proc/1/comm'` | `boxsh` (PID namespace active) |
| `boxsh --sandbox --new-net-ns -c 'ping -c1 -W1 8.8.8.8'` | `Network is unreachable` |
| `--bind cow:SRC:DST` writes isolated from SRC | confirmed |

**Reverse verification — stashing the patch reliably reproduces the failure:**

```
$ git stash
$ rm -rf build && cmake -B build -DCMAKE_BUILD_TYPE=Release
$ cmake --build build -j8 2>&1 | grep -E 'error|histedit'
/home/logic/boxsh/third_party/dash-0.5.12/src/myhistedit.h:34:10:
fatal error: histedit.h: No such file or directory
```

## Risk

Low. The change only reorders a CMake variable definition and adds one include path plus one `add_dependencies` edge for a target that already depends on `libedit` at link time via `boxsh`. No runtime behavior changes.