### PR TITLE
fix: wire dash build to vendored libedit headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,13 @@ ExternalProject_Add(libedit_vendored
     BUILD_BYPRODUCTS ${LIBEDIT_INSTALL_DIR}/lib/libedit.a
 )
 
+# dash's interactive editing sources include <histedit.h>, which is provided by
+# the vendored libedit install tree rather than the system headers on a clean
+# machine. Make that include path visible to dash_static and ensure libedit is
+# installed before dash compiles.
+target_include_directories(dash_static PRIVATE ${LIBEDIT_INSTALL_DIR}/include)
+add_dependencies(dash_static libedit_vendored)
+
 # ---------------------------------------------------------------------------
 # libvterm (vendored, pure-C VT220/xterm emulator used by Neovim)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the vendored libedit include directory to `dash_static`
- make `dash_static` depend on `libedit_vendored` so clean builds install `histedit.h` before dash compiles

## Why
A clean local build currently fails in dash with:

```text
third_party/dash-0.5.12/src/myhistedit.h:34:10: fatal error: histedit.h: No such file or directory
```

`histedit.h` comes from the repo's vendored libedit install tree, but `dash_static` did not include that directory and had no explicit dependency on the vendored libedit target.

## Reproduction environment
Reproduced from a clean checkout of upstream `master` in a separate worktree on this host:

- OS: Debian GNU/Linux 13 (trixie)
- Kernel: `Linux six225 6.12.73+deb13-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.73-1 (2026-02-17) x86_64 GNU/Linux`
- Architecture: `x86_64`
- `git`: `2.47.3`
- `cmake`: `3.31.6`
- `cc`/`c++`: GCC `14.2.0`
- `node`: `v22.22.2`
- Important precondition: no system libedit headers were installed (`/usr/include/histedit.h` was absent)

That last point matters: the vendored libedit build succeeds and installs `histedit.h` into the build tree, but `dash_static` on `master` never gets that include directory.

## Exact repro
```sh
git clone https://github.com/xicilion/boxsh
cd boxsh
cmake -S . -B build
cmake --build build -j4
```

Observed result on `master`:

```text
/opt/work/boxsh-repro/third_party/dash-0.5.12/src/myhistedit.h:34:10: fatal error: histedit.h: No such file or directory
   34 | #include <histedit.h>
      |          ^~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/dash_static.dir/build.make:149: CMakeFiles/dash_static.dir/third_party/dash-0.5.12/src/eval.c.o] Error 1
```

At the same time, the vendored libedit step had already installed the header here:

```text
build/libedit-prefix/include/histedit.h
```

and `build/CMakeFiles/dash_static.dir/flags.make` on `master` showed only:

```text
C_INCLUDES = -I<repo>/third_party/dash-0.5.12/src -I<repo>/third_party/dash-0.5.12
```

so `dash_static` never saw `build/libedit-prefix/include`.

## Test Plan
- `cmake -S . -B build-pr`
- `cmake --build build-pr -j4`
- `BOXSH=$PWD/build-pr/boxsh node --test sdk/js/test/all.test.mjs`
- `BOXSH=$PWD/build-pr/boxsh node --test tests/index.test.mjs` *(573 pass / 6 fail locally, spanning 5 failing suites; remaining failures appear to be existing sandbox/root-environment issues unrelated to this build wiring fix)*
