### PR TITLE
fix(rpc): handle POLLNVAL to break busy loop on macOS orphan processes

### DIFF
--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1203,6 +1203,11 @@ public:
             if (n == 0) { eof_ = true; return false; }
             if (errno == EINTR) continue;
             if (errno == EAGAIN || errno == EWOULDBLOCK) return true;
+            // Any other read error (EBADF, EIO, fd invalidated, etc.) — treat as EOF.
+            // Without this, callers see fill()==false but eof()==false and re-enter poll(),
+            // which on macOS keeps returning POLLNVAL for an invalid stdin (e.g. parent
+            // closed the pipe) → busy loop.
+            eof_ = true;
             return false;
         }
     }
@@ -1506,7 +1511,11 @@ void rpc_run_loop(int fd_in, int fd_out, WorkerPool &pool) {
 
         size_t pfd_off = 0;
         if (poll_stdin) {
-            if (pfds[0].revents & (POLLIN | POLLHUP | POLLERR)) {
+            // POLLNVAL must be handled too: on macOS, poll() on a non-blocking fd that
+            // was redirected from /dev/null or whose pipe peer closed returns POLLNVAL.
+            // Treating it like other error/eof events lets reader.fill() set eof_ and
+            // breaks the busy loop.
+            if (pfds[0].revents & (POLLIN | POLLHUP | POLLERR | POLLNVAL)) {
                 if (!reader.fill() && reader.overflowed()) {
                     RpcResponse err;
                     err.id = nullptr;


### PR DESCRIPTION
## Summary

On macOS, an orphaned `boxsh --rpc` process consumes 80–90% CPU indefinitely in a tight `poll(2)` busy loop. Root cause: when the parent closes its end of the stdin pipe (or stdin was redirected from `/dev/null`), macOS `poll(2)` returns `POLLNVAL` on the stdin fd, but `rpc_run_loop` only checks `POLLIN | POLLHUP | POLLERR` — so `LineReader::fill()` is never invoked, `eof_` stays `false`, and the loop never breaks.

This PR adds two coordinated, minimal changes that together turn the busy loop into a clean EOF / process exit.

## Real-world impact

I noticed this after finding a single orphaned `boxsh --rpc --workers 1` process on my Mac that had accumulated **38,463 minutes of CPU time over 26 days** (effectively pinning one core at 100% for 26 days straight). The process had `PPID=1`, stdin redirected from `/dev/null`, and stdout pointing to a broken pipe — a benchmark leftover. Because `SIGPIPE` is ignored (`main.cpp:411`), nothing terminates the orphan and it silently burns power, drains laptop batteries, and adds thermal load with no log, no UI, no `ps`-top visibility.

Any workflow that uses `boxsh --rpc` as a long-running backend (IDE integrations, agent frameworks, test harnesses) can hit this whenever the parent dies unexpectedly.

## Reproduction

```bash
bash -c '/path/to/boxsh --rpc --workers 1 < /dev/null > /tmp/test.out 2>&1 &'
# Kill the parent shell; observe the orphan in `top -o cpu`:
# its CPU should pin near 100% on a single core indefinitely.
```

I verified the root cause with `lldb` sampling (`nfds=1, fd=0, events=POLLIN` looping with no progress) and a standalone C reproducer confirming that `poll(2)` on macOS returns `POLLNVAL (0x20)` for stdin redirected from `/dev/null` with `O_NONBLOCK`.

## Root cause (the bug chain)

1. macOS `poll(2)` returns `POLLNVAL` for stdin redirected from `/dev/null` (or whose pipe peer has closed) — different from Linux, which returns `POLLHUP` in the equivalent scenarios.
2. `rpc_run_loop` only inspects `POLLIN | POLLHUP | POLLERR`, so the `POLLNVAL` event is silently dropped.
3. `LineReader::fill()` is therefore never called.
4. `eof_` stays `false`, so `poll_stdin = !reader.eof() && ...` remains `true` on every iteration.
5. `poll()` returns immediately again (the revents bit is still set) → tight busy loop → ~100% CPU on one core.

**Fixing only one of the two layers is not enough**: even if `POLLNVAL` is added to the mask, `LineReader::fill()` would still see `read()` return `-1` (non-`EAGAIN`/`EINTR`) and `return false` without setting `eof_`, so the next iteration re-enters the same state.

## The fix

Two minimal changes in `src/rpc.cpp` (10 insertions, 1 deletion):

1. `LineReader::fill()`: when `read()` returns a non-recoverable error (anything other than `EINTR` / `EAGAIN` / `EWOULDBLOCK`), set `eof_ = true` before returning `false`, so callers can observe EOF when the fd has been invalidated.

2. `rpc_run_loop` poll handling: add `POLLNVAL` to the stdin `revents` mask so that `LineReader::fill()` is actually invoked when the fd becomes invalid, allowing fix (1) to take effect.

Both changes are accompanied by inline comments explaining the macOS-specific reasoning.

## Why Linux is unaffected

`poll(2)` on Linux does not return `POLLNVAL` for the `/dev/null` / closed-pipe scenarios that trigger this on macOS — it returns `POLLHUP`, which the existing code already handles correctly. The new code path is therefore a no-op on Linux: `read()` errors that previously caused `fill()` to silently return `false` will now also set `eof_`, but `eof_` only matters when the caller subsequently fails to make progress, which is exactly the scenario this PR is addressing.

## Scope of changes

Intentionally minimal. I considered but did **not** make these adjacent changes, to keep the diff focused:

- **`worker_pool.cpp` poll handling**: its fds are pipes that boxsh creates internally and the existing `read()` error path already marks them `done`, so no busy loop is possible there. Not touched.
- **Wider use of `POLLNVAL` in other poll sites** (`busy` / `pending_tools` in the same loop): those fds are owned children, not externally-supplied stdin, so `POLLNVAL` would be a real bug worth surfacing rather than papering over. Not touched.
- **Active orphan-exit detection** (e.g. via `prctl`/`kevent` parent-death notification): a worthwhile follow-up but out of scope here — this PR just makes the existing EOF path work correctly when the fd is invalidated.

## Test plan

- [x] Manual reproduction on macOS (Darwin 25.2.0, arm64): orphaned `boxsh --rpc --workers 1` now exits cleanly when the parent dies, instead of pinning a core at 100%.
- [x] `lldb` sampling on a patched build confirms `poll` no longer wakes with `POLLNVAL` and the process exits the loop via the existing EOF path.
- [ ] CI regression on Linux: I expect no behavior change since the new code path is unreachable on Linux for the relevant fds — happy to extend `tests/` if you'd like a regression test for the macOS-specific path (e.g. a test that spawns `boxsh --rpc` as a detached child, kills the parent, and asserts the orphan exits within a small window).
